### PR TITLE
Adds Dockerfile to encapsulate configuration/scripts, other minor tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM neo4j:4.4
+
+# this image will be deployed as part of the monarch-stack-v3
+# (https://github.com/monarch-initiative/monarch-stack-v3)
+
+# to faciliate deployment, we're copying in configuration and other support
+# scripts into the image rather than having to copy them to the neo4j host at
+# runtime.
+
+COPY ./scripts /scripts
+COPY ./neo4j/conf /var/lib/neo4j/conf

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,8 @@ services:
   #      - neo4j
 
   neo4j:
-    image: neo4j:4.4
+    image: us-central1-docker.pkg.dev/monarch-initiative/monarch-api/monarch-neo4j:4.4
+    build: .
     env_file:
       - .env
     ports:
@@ -29,7 +30,7 @@ services:
       - neo4j-data:/data
       - ./plugins:/plugins
       - ./dumps:/dumps
-      - ./scripts:/scripts
-      - ./neo4j/conf:/var/lib/neo4j/conf
     # NEO4J_DUMP_FILENAME can be defined within the .env file
+    # (in fact, it needs to be defined for this file to parse, e.g. to use
+    # `docker compose build` or any other compose command)
     entrypoint: /scripts/load_and_boot_neo4j.sh $NEO4J_DUMP_FILENAME

--- a/scripts/load_and_boot_neo4j.sh
+++ b/scripts/load_and_boot_neo4j.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-NEO4J_DATABASE=${1:-monarch-kg}
-NEO4J_DUMP_FILENAME=${1:-${NEO4J_DATABASE}.neo4j.dump}
+DEFAULT_NEO4J_DATABASE="monarch-kg"
+
+NEO4J_DUMP_FILENAME=${1:-${DEFAULT_NEO4J_DATABASE}.neo4j.dump}
+NEO4J_DATABASE=${2:-${DEFAULT_NEO4J_DATABASE}}
 
 [ ! -z ${DO_LOAD} ] && \
     echo "Loading Neo4j dump file '$NEO4J_DUMP_FILENAME' into database '$NEO4J_DATABASE'" && \
-    neo4j-admin load --from=/dumps/$NEO4J_DUMP_FILENAME
+    neo4j-admin load --force --from=/dumps/$NEO4J_DUMP_FILENAME
 
 chown -R neo4j /data
 

--- a/scripts/load_and_boot_neo4j.sh
+++ b/scripts/load_and_boot_neo4j.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 NEO4J_DATABASE=${1:-monarch-kg}
-NEO4J_DUMP_FILENAME=${1:-$NEO4J_DATABASE.neo4j.dump}
+NEO4J_DUMP_FILENAME=${1:-${NEO4J_DATABASE}.neo4j.dump}
 
 [ ! -z ${DO_LOAD} ] && \
     echo "Loading Neo4j dump file '$NEO4J_DUMP_FILENAME' into database '$NEO4J_DATABASE'" && \


### PR DESCRIPTION
This PR adds a Dockerfile that's based on `neo4j:4.4`, like the original, but inlines configuration files and scripts into the image to make deploying it a little easier. The built image is pushed to the GCP Artifact Registry at the following location: `us-central1-docker.pkg.dev/monarch-initiative/monarch-api/monarch-neo4j:4.4`. The `docker-compose.yaml` file has been updated to build the custom image and to tag it with that artifact registry reference.

The PR also includes some minor tweaks to how [/scripts/load_and_boot_neo4j.sh](https://github.com/monarch-initiative/monarch-neo4j/blob/67074b5fca22b14c7196da5c3ca473e086d81065/scripts/load_and_boot_neo4j.sh) works:
1. The first argument is now the dumpfile name rather than the database name, which seems to be in keeping with the documentation. If unspecified, it will default to `monarch-kg.neo4j.dump`.
2. The second argument is now the database name; if unspecified, it defaults to `monarch-kg`.
3. Added the `--force` argument to `neo4j-admin`, which replaces the existing database on load, so that we don't fail to start the server if `DO_LOAD` is specified with an existing database in place.

Just FYI, ultimately this container will be deployed as part of https://github.com/monarch-initiative/monarch-stack-v3.
